### PR TITLE
🐛Fix for forAllValuesIfExists

### DIFF
--- a/src/classes/condition-modifiers-manager.ts
+++ b/src/classes/condition-modifiers-manager.ts
@@ -28,10 +28,17 @@ export class ConditionModifiersManager implements IConditionModifiersManager {
       if (!this.exists(environmentValue)) {
         continue;
       }
+      let matchesOne = false;
+
       for (const conditionValue of conditionValues) {
-        if (!handler(conditionValue, environmentValue)) {
-          return false;
+        if (handler(conditionValue, environmentValue)) {
+          matchesOne = true;
+          break;
         }
+      }
+
+      if (!matchesOne) {
+        return false;
       }
     }
     return true;

--- a/test/classes/condition-evaluator.test.ts
+++ b/test/classes/condition-evaluator.test.ts
@@ -128,5 +128,31 @@ describe('ConditionEvaluator', () => {
       }, { foo: { id: 1 }, bar: { id: 1 } });
       expect(evaluation.succeeded()).to.equal(true);
     });
+    it('should compute forAllValues', () => {
+      const evaluation = conditionEvaluator.evaluate({
+        numberEquals: {
+          forAllValues: {
+            'foo.ids': '{{{bar.ids}}}'
+          }
+        }
+      }, {
+        'foo': { 'ids': [1, 2] },
+        'bar': { 'ids': [1, 2] }
+      });
+      expect(evaluation.succeeded()).to.equal(true);
+    });
+    it('should compute forAllValuesIfExists', () => {
+      const evaluation = conditionEvaluator.evaluate({
+        numberEquals: {
+          forAllValuesIfExists: {
+            'foo.ids': '{{{bar.ids}}}'
+          }
+        }
+      }, {
+        'foo': { 'ids': [1, 2] },
+        'bar': { 'ids': [1, 2] }
+      });
+      expect(evaluation.succeeded()).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
I'm not 100% sure how `forAllValuesIfExists` is supposed to work, but this fix will make it behave like `forAllValues` (just with the "exists" permissiveness).